### PR TITLE
"loaded modules": find also submodules

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,18 @@
+issubmodule(m::Module, s) = s isa Module && parentmodule(s) == m && m != s
+
+function submodules(m::Module)
+    symbols = Core.eval.(Ref(m), filter!(y -> isdefined(m, y), names(m, all=true)))
+    filter!(x -> issubmodule(m, x), symbols)
+end
+
+# list of recursive submodules of m, including m itself
+function recsubmodules(m::Module)
+    subs = submodules(m)
+    if isempty(subs)
+        recs = subs
+    else
+        recs = mapreduce(recsubmodules, vcat, subs)
+    end
+    pushfirst!(recs, m)
+    recs
+end

--- a/test/FakePackage/src/FakePackage.jl
+++ b/test/FakePackage/src/FakePackage.jl
@@ -19,4 +19,14 @@ end
     push!(RUN, 2)
 end
 
+module Submodule
+
+using InlineTest
+
+@testset "check that Submodule is noticed by ReTest" begin
+    @test true
+end
+
+end # Submodule
+
 end

--- a/test/FakePackage/test/runtests.jl
+++ b/test/FakePackage/test/runtests.jl
@@ -7,3 +7,6 @@ FakePackage.runtests(r"begin-end")
 @test FakePackage.RUN == [1, 2, 1]
 FakePackage.runtests(r" for")
 @test FakePackage.RUN == [1, 2, 1, 2]
+
+retest(dry=true) # only to update InlineTest.TESTED_MODULES
+@test FakePackage.Submodule in ReTest.TESTED_MODULES


### PR DESCRIPTION
We use `Base.loaded_modules` to find modules using `ReTest` which didn't
have a chance to register themselves in `InlineTest.TESTED_MODULES`.
Here we look also for submodules using `ReTest`.