### PR TITLE
dryrun: keep track of loop variables from parent testsets

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -635,6 +635,33 @@ end # MultiLoops
     check(MultiLoops, "1 1", [(1, 1)])
 end
 
+module LoopsVariablesDryrun
+# check that even with for-iterators which depend on previous loop variables,
+# dryrun mode is able to compute them and corresponding descriptions,
+# and filter accordingly
+
+using ReTest
+
+@testset "a$i" for i=1:2
+    @testset "b$j" for j=1:i
+        @test true
+    end
+end
+end
+
+@chapter Loops begin
+    # no match, so this it at least filtered for final testsets
+    check(LoopsVariablesDryrun, "a1/b3", dry=true, verbose=9, [], output="""
+1| a1
+1| a2
+""")
+    check(LoopsVariablesDryrun, "a2/b1", dry=true, verbose=9, [], output="""
+1| a1
+1| a2
+2|   b1
+""")
+end
+
 # * Anonym ...................................................................
 
 module Anonym


### PR DESCRIPTION
Partially fixes #27.

The full fix might be to make `resolve!` also keep track of these
loop variables; but this would involve storing lists of collected
iterators for each nested testset: once we evaluate an iterator
for filtering in `resolve!`, we have to store it in case
it has some random behavior (e.g. `rand(1:9, i)` where `i` is
a loop variable from a parent testset), in which case re-evaling
it at execution time would lead to inconsistency.
The testset tree would also have to be traversed depth-first by also
unfolding testset-for. This could be a nice improvement if the perfs
don't suffer (instead of storing parent strings subjects and looping
through them, we would store iterators and recurse into them).