### PR TITLE
hijack: be more precise with `include=:static`

### DIFF
--- a/test/Hijack/test/include_static_included1.jl
+++ b/test/Hijack/test/include_static_included1.jl
@@ -1,4 +1,6 @@
-@testset "include_static_included1 $i" for i=1:2
+# with @eval, we test that include=:static works even for a non-toplevel
+# @testset, what matters is that a testset is defined after including the file
+@eval @testset "include_static_included1 $i" for i=1:2
     @test true
     @testset "nested include_static_included1" begin
         @test true


### PR DESCRIPTION
Instead of fetching top-level `@testset` expressions, we inspect
newly added testsets in the module via `get_tests(mod).news`.
This allows for example to catch testsets defined by
meta-programming.