### PR TITLE
fixed inappropriate deprecation warnings when checking for sub-modules

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,10 @@ Maybe{T} = Union{T,Nothing}
 issubmodule(m::Module, s) = s isa Module && parentmodule(s) == m && m != s
 
 function submodules(m::Module)
-    symbols = Core.eval.(Ref(m), filter!(y -> isdefined(m, y), names(m, all=true)))
+    nms = filter!(names(m, all=true)) do y
+        Base.isdefined(m, y) && !Base.isdeprecated(m, y)
+    end
+    symbols = Core.eval.(Ref(m), nms)
     filter!(x -> issubmodule(m, x), symbols)
 end
 


### PR DESCRIPTION
This fixes #37 and #40.

I don't believe this can break anything since the function in question is used for checking for sub-modules which are unaffected by this check.

I think it's important to fix this since testing is precisely the context in which you'd want to check for deprecations so it's profoundly unhelpful to have the testing module itself throw bogus deprecation warnings.