### PR TITLE
fix integer type mismatch on x86

### DIFF
--- a/src/ReTest.jl
+++ b/src/ReTest.jl
@@ -1485,7 +1485,7 @@ function fetchtests((mod, pat), verbose, module_header, maxidw; static, strict, 
     descwidth = 0
     hasbroken = false
 
-    id = 1
+    id = Int64(1)
     warned = Ref(false)
 
     for ts in tests


### PR DESCRIPTION
`resolve!` takes an `id::Int64`, but `fetchtests` tries to assign an integer literal into it, which is an `Int32` for x86. This commit explicitly converts the literal into `Int64`.