### PR TITLE
Fixes for recent Julia versions

### DIFF
--- a/src/testset.jl
+++ b/src/testset.jl
@@ -46,6 +46,11 @@ function scrub_exc_stack(stack)
     return Any[ (x[1], scrub_backtrace(x[2])) for x in stack ]
 end
 
+# Compat for catch_stack(), which was deprecated in 1.7
+@static if VERSION < v"1.7"
+    current_exceptions() = Base.catch_stack()
+end
+
 mutable struct Format
     stats::Bool
     desc_align::Int
@@ -531,7 +536,7 @@ function testset_beginend(mod::Module, isfinal::Bool, pat::Pattern, id::Int64, d
                 # something in the test block threw an error. Count that as an
                 # error in this test set
                 record(ts, Error(:nontest_error, Expr(:tuple), err,
-                                 Base.catch_stack(), $(QuoteNode(source))))
+                                 current_exceptions(), $(QuoteNode(source))))
             finally
                 copy!(RNG, oldrng)
                 setresult!($marks, ts.subject, !anyfailed(ts))
@@ -594,7 +599,7 @@ function testset_forloop(mod::Module, isfinal::Bool, pat::Pattern, id::Int64,
                 err isa InterruptException && rethrow()
                 # Something in the test block threw an error. Count that as an
                 # error in this test set
-                record(ts, Error(:nontest_error, Expr(:tuple), err, Base.catch_stack(), $(QuoteNode(source))))
+                record(ts, Error(:nontest_error, Expr(:tuple), err, current_exceptions(), $(QuoteNode(source))))
                 setresult!($marks, ts.subject, false)
             end
         end

--- a/src/testset.jl
+++ b/src/testset.jl
@@ -672,9 +672,13 @@ macro stats(yes, ex)
     end
 end
 
-cumulative_compile_time_ns() =
-    isdefined(Base, :cumulative_compile_time_ns) ?
+@static if VERSION >= v"1.9"
+    # In 1.9 this function was changed to return a tuple of (compile_time, recompilation_time)
+    cumulative_compile_time_ns() = sum(Base.cumulative_compile_time_ns())
+else
+    cumulative_compile_time_ns() = isdefined(Base, :cumulative_compile_time_ns) ?
         Base.cumulative_compile_time_ns() :
         UInt(0)
+end
 
 end # module


### PR DESCRIPTION
This has two fixes for issues I came across on 1.10:
- Stop using the deprecated `Base.catch_stack()` on >= 1.7 (1f5d44a)
- Update the use of `Base.cumulative_compile_time_ns()` on >= 1.9 (6c7dcbb). Without this the tests would hang when `stats=true` was passed because `print_test_results()` would fail, which caused the `printer` task to fail, which meant that there would be no readers `take!()`'ing from the worker `outchan`, which caused everything to hang.

Fixes #49.