### PR TITLE
Fix 32 bit support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
           - { os: ubuntu-latest, version: '1.6', arch: x64}
           - { os: ubuntu-latest, version: '^1.7.0-0', arch: x64}
           - { os: ubuntu-latest, version: 'nightly', arch: x64}
+          - { os: ubuntu-latest, version: '1', arch: x86 }
           - { os: windows-latest, version: '1', arch: x64}
           - { os: macOS-latest, version: '1', arch: x64}
 

--- a/src/ReTest.jl
+++ b/src/ReTest.jl
@@ -1485,7 +1485,7 @@ function fetchtests((mod, pat), verbose, module_header, maxidw; static, strict, 
     descwidth = 0
     hasbroken = false
 
-    id = 1
+    id = Int64(1)
     warned = Ref(false)
 
     for ts in tests


### PR DESCRIPTION
Previously running ReTest.jl on 32 bit machines would fail because the `id` variable would have type Int32 (because it's initialized with a literal) but the function it was getting passed to (`resolve!()`) expected a Int64. Also added a 32 bit test to the CI matrix.

This is based on top of #54 so that the CI passes, once that's merged I'll rebase this branch.