### PR TITLE
Record a failing @test_logs as a failure instead of erroring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,10 +20,10 @@ jobs:
       matrix:
         include:
           - { os: ubuntu-latest, version: 'nightly', arch: x64}
-          - { os: ubuntu-latest, version: '1.13.0-rc1', arch: x64 }
-          - { os: ubuntu-latest, version: '1.13.0-rc1', arch: x86 }
-          - { os: windows-latest, version: '1.13.0-rc1', arch: x64}
-          - { os: macOS-latest, version: '1.13.0-rc1', arch: aarch64}
+          - { os: ubuntu-latest, version: '1.13', arch: x64 }
+          - { os: ubuntu-latest, version: '1.13', arch: x86 }
+          - { os: windows-latest, version: '1.13', arch: x64}
+          - { os: macOS-latest, version: '1.13', arch: aarch64}
 
     steps:
       - uses: actions/checkout@v4

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTest"
 uuid = "e0db7c4e-2690-44b9-bad6-7687da720f89"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Rafael Fourquet <fourquet.rafael@gmail.com>"]
 
 [deps]

--- a/src/testset.jl
+++ b/src/testset.jl
@@ -93,6 +93,9 @@ ReTestSet(desc::String; verbose::Bool=false) =
 
 # For a non-passed result, simply store the result
 record(ts::ReTestSet, t::Union{Broken,Fail,Error}) = (push!(ts.results, t); t)
+# Convert a `LogTestFailure` to `Fail` like `Test.DefaultTestSet`
+record(ts::ReTestSet, t::Test.LogTestFailure) =
+    (push!(ts.results, Fail(:test, t.orig_expr, t.logs, nothing, nothing, t.source, false)); t)
 # For a passed result, do not store the result since it uses a lot of memory
 record(ts::ReTestSet, t::Pass) = (ts.n_passed += 1; t)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1820,8 +1820,18 @@ end
         replace(content, "load_path_function() = 1" => "load_path_function() = 2")
     end
 
-    Revise.revise()
     try
+        # Queue the tracked files explicitly, as Revise.revise() only processes changes
+        # that its file watcher task has already picked up, which is racy.
+        # Revise.revise(mod) can't be used since it looks up PkgId(mod), i.e. "Main".
+        @lock Revise.revise_lock for (id, pkgdata) in Revise.pkgdatas
+            if id.uuid === nothing && startswith(id.name, "Main.")
+                for file in pkgdata.info.files
+                    push!(Revise.revision_queue, (pkgdata, file))
+                end
+            end
+        end
+        Revise.revise()
         Test.@testset "revise works" begin
             retest(HijackTests2)
             @test Hijack.RUN == [2, 5, 4]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1280,6 +1280,20 @@ end # Failing
 """)
 end
 
+module FailingTestLogs
+using ReTest
+using Test: @test_logs
+
+@testset "logs fail" begin
+    # pattern expects "x", actual log is "y" → LogTestFailure
+    @test_logs (:info, "x") @info "y"
+end
+end # FailingTestLogs
+
+@chapter FailingTestLogs begin
+    @test_throws Test.TestSetException retest(FailingTestLogs)
+end
+
 module FailingLoops
 # we test that toplevel testset-for don't make retest unresponsive
 
@@ -1882,4 +1896,29 @@ end
         retest(HijackInclude)
     end
     @test Hijack.RUN == [1, 2, 3, 2, 3]
+end
+
+Test.@testset "record(::ReTestSet, ::LogTestFailure)" begin
+    ReTestSet = ReTest.Testset.ReTestSet
+    record = ReTest.Testset.record
+    anyfailed = ReTest.Testset.anyfailed
+    get_test_counts = ReTest.Testset.get_test_counts
+
+    logfail = Test.LogTestFailure(:(@info "x"), LineNumberNode(1, :file),
+                                  Any[(:info, "x")], Any[])
+
+    # A failing `@test_logs` is recordable, and counts as a failure.
+    ts = ReTestSet(Main, "lt")
+    @test record(ts, logfail) === logfail
+    @test anyfailed(ts)
+    _, fails, errors, _ = get_test_counts(ts)
+    @test fails == 1
+    @test errors == 0
+
+    # A testset with no failing result reports none.
+    ts2 = ReTestSet(Main, "lt_empty")
+    @test !anyfailed(ts2)
+    _, fails2, errors2, _ = get_test_counts(ts2)
+    @test fails2 == 0
+    @test errors2 == 0
 end


### PR DESCRIPTION
A failing `@test_logs` produces a `Test.LogTestFailure`, which is not a
`Fail`/`Error`/`Broken`, so `ReTestSet` had no `record` method for it and the
failure threw a `MethodError` instead of being reported.

Convert `LogTestFailure` to `Fail` in `record`, matching
`Test.DefaultTestSet`, so it is counted and printed like any other failure.

Adds a unit test on `record`/`anyfailed`/`get_test_counts`, and an integration
module whose failing `@test_logs` causes `retest` to throw `TestSetException`
(not `MethodError`).

Fixes #50
